### PR TITLE
Increase file upload size to 5M

### DIFF
--- a/conf/salt/project/web/balancer.sls
+++ b/conf/salt/project/web/balancer.sls
@@ -122,7 +122,6 @@ nginx_conf:
         source_dir: "{{ vars.source_dir }}"
         log_dir: "{{ vars.log_dir }}"
         ssl_dir: "{{ vars.ssl_dir }}"
-        client_max_body_size: "5m"
         servers:
 {% for host, ifaces in vars.web_minions.items() %}
 {% set host_addr = vars.get_primary_ip(ifaces) %}

--- a/conf/salt/project/web/balancer.sls
+++ b/conf/salt/project/web/balancer.sls
@@ -122,6 +122,7 @@ nginx_conf:
         source_dir: "{{ vars.source_dir }}"
         log_dir: "{{ vars.log_dir }}"
         ssl_dir: "{{ vars.ssl_dir }}"
+        client_max_body_size: "5m"
         servers:
 {% for host, ifaces in vars.web_minions.items() %}
 {% set host_addr = vars.get_primary_ip(ifaces) %}

--- a/conf/salt/project/web/site.conf
+++ b/conf/salt/project/web/site.conf
@@ -4,6 +4,9 @@ upstream {{ pillar['project_name'] }}  {
 {% endfor %}
 }
 
+# file upload limit (default is 1 megabyte)
+client_max_body_size 5m;
+
 {# Redirect everything to HTTPS #}
 server {
     listen 80;
@@ -65,9 +68,6 @@ server {
 
     location / {
         gzip off;
-
-        # file upload limit (default is 1 megabyte)
-        client_max_body_size {{ client_max_body_size }};
 
         {% if 'http_auth' in pillar %}
         auth_basic "Restricted";
@@ -138,9 +138,6 @@ server {
 
     location / {
         gzip off;
-
-        # file upload limit (default is 1 megabyte)
-        client_max_body_size {{ client_max_body_size }};
 
         {% if 'http_auth' in pillar %}
         auth_basic "Restricted";

--- a/conf/salt/project/web/site.conf
+++ b/conf/salt/project/web/site.conf
@@ -66,6 +66,9 @@ server {
     location / {
         gzip off;
 
+        # file upload limit (default is 1 megabyte)
+        client_max_body_size {{ client_max_body_size }};
+
         {% if 'http_auth' in pillar %}
         auth_basic "Restricted";
         auth_basic_user_file {{ auth_file }};
@@ -135,6 +138,9 @@ server {
 
     location / {
         gzip off;
+
+        # file upload limit (default is 1 megabyte)
+        client_max_body_size {{ client_max_body_size }};
 
         {% if 'http_auth' in pillar %}
         auth_basic "Restricted";


### PR DESCRIPTION
Addresses #5 

I'm not sure if the directive is needed in both places or not. I would think
it is since I could see either server (8088 or 443) rejecting the request if
the size exceeded its limit.

Let me know if I should test this on vagrant first.