### PR TITLE
Use network.host to set bind AND publish addresses (to 127.0.0.1)

### DIFF
--- a/conf/salt/project/elasticsearch/elasticsearch.yml
+++ b/conf/salt/project/elasticsearch/elasticsearch.yml
@@ -1,8 +1,5 @@
-network.bind_host: 127.0.0.1
-cluster:
-  name: {{ pillar['project_name'] }}_{{ pillar['environment'] }}
-node:
-  name: {{ grains['id'] }}
+network.host: 127.0.0.1
+node.local: true
 
 # Don't form ad-hoc clusters
 # See https://www.elastic.co/guide/en/elasticsearch/guide/current/_important_configuration_changes.html#_prefer_unicast_over_multicast


### PR DESCRIPTION
Disable cluster/node configuration.

node.local with existing multicast config is supposed to isolate this search node from other nodes.