### PR TITLE
SC-133 - enable New Relic monitoring for Elasticsearch

### DIFF
--- a/conf/pillar/project.sls
+++ b/conf/pillar/project.sls
@@ -3,3 +3,5 @@ project_name: service_info
 python_version: 3.4
 
 postgresql_version: 9.4
+
+elasticsearch_newrelic: true

--- a/conf/salt/project/_vars.sls
+++ b/conf/salt/project/_vars.sls
@@ -28,3 +28,5 @@
 {% set worker_minions = salt['mine.get']('roles:worker', 'network.interfaces', expr_form='grain') %}
 {% set app_minions = salt['mine.get']('roles:(worker|web)', 'network.interfaces', expr_form='grain_pcre') %}
 {% set balancer_minions = salt['mine.get']('roles:balancer', 'network.interfaces', expr_form='grain') %}
+
+{% set use_newrelic = salt['pillar.get']('secrets:NEW_RELIC_LICENSE_KEY', False) %}

--- a/conf/salt/project/_vars.sls
+++ b/conf/salt/project/_vars.sls
@@ -29,4 +29,4 @@
 {% set app_minions = salt['mine.get']('roles:(worker|web)', 'network.interfaces', expr_form='grain_pcre') %}
 {% set balancer_minions = salt['mine.get']('roles:balancer', 'network.interfaces', expr_form='grain') %}
 
-{% set use_newrelic = salt['pillar.get']('secrets:NEW_RELIC_LICENSE_KEY', False) %}
+{% set use_newrelic = salt['pillar.get']('secrets:newrelic_license_key', False) %}

--- a/conf/salt/project/elasticsearch/elasticsearch.yml
+++ b/conf/salt/project/elasticsearch/elasticsearch.yml
@@ -1,6 +1,11 @@
 network.host: 127.0.0.1
 node.local: true
 
+cluster:
+  name: {{ pillar['project_name'] }}_{{ pillar['environment'] }}
+node:
+  name: {{ grains['id'] }}
+
 # Don't form ad-hoc clusters
 # See https://www.elastic.co/guide/en/elasticsearch/guide/current/_important_configuration_changes.html#_prefer_unicast_over_multicast
 discovery.zen.ping.multicast.enabled: false

--- a/conf/salt/project/elasticsearch/init.sls
+++ b/conf/salt/project/elasticsearch/init.sls
@@ -5,7 +5,7 @@
 
 {% if monitor_with_newrelic %}
 include:
-  - newrelic_npi
+  - project.newrelic_npi
 {% endif %}
 
 elasticsearch-apt-repo:

--- a/conf/salt/project/newrelic_npi/README.rst
+++ b/conf/salt/project/newrelic_npi/README.rst
@@ -10,7 +10,7 @@ If you want to install an NPI compatible plugin, include this state in
 your own state file::
 
     include:
-    - newrelic_npi
+    - project.newrelic_npi
 
 Then see the ``elasticsearch/init.sls`` file for an example of the rather convoluted
 way to use it to install a New Relic plugin.  (Anyone want to write an NPI state for

--- a/conf/salt/project/newrelic_npi/README.rst
+++ b/conf/salt/project/newrelic_npi/README.rst
@@ -1,0 +1,17 @@
+New Relic NPI
+=============
+
+NPI is the `New Relic Platform Installer <https://docs.newrelic.com/docs/plugins/plugins-new-relic/installing-plugins/installing-npi-compatible-plugin>`_
+that can be used to easily install compatible plugins.
+
+This state will create a ``/usr/share/npi`` directory and install NPI into it.
+
+If you want to install an NPI compatible plugin, include this state in
+your own state file::
+
+    include:
+    - newrelic_npi
+
+Then see the ``elasticsearch/init.sls`` file for an example of the rather convoluted
+way to use it to install a New Relic plugin.  (Anyone want to write an NPI state for
+Salt?)

--- a/conf/salt/project/newrelic_npi/init.sls
+++ b/conf/salt/project/newrelic_npi/init.sls
@@ -18,6 +18,6 @@ install_npi:
 
 configure_npi:
   cmd.run:
-    - name: ./npi set license_key {{ pillar['secrets']['NEW_RELIC_LICENSE_KEY'] }} && ./npi set user {{ pillar['project_name'] }} && ./npi set distro debian
+    - name: ./npi set license_key {{ pillar['secrets']['newrelic_license_key'] }} && ./npi set user {{ pillar['project_name'] }} && ./npi set distro debian
     - cwd: /usr/share/npi
 {% endif %}

--- a/conf/salt/project/newrelic_npi/init.sls
+++ b/conf/salt/project/newrelic_npi/init.sls
@@ -1,0 +1,23 @@
+# Install New Relic Platform Installer under /usr/share/npi
+{% import 'project/_vars.sls' as vars with context %}
+
+{% if vars.use_newrelic %}
+{% set version = "0.1.5" %}
+{% set tarball = "platform_installer-linux-x64-v" + version + ".tar.gz" %}
+{% set url = "https://download.newrelic.com/npi/v" + version + "/" + tarball %}
+{% set hash = "sha512=92aaec9ae56abb05bce3663150eddb01425ec8718f17e987a1e7f7c812a3e3fc3a7a217944413f857a5e5ec98b66d7ab6927db9bb981b6f98eee1c860c3c3306" %}
+
+install_npi:
+  archive.extracted:
+    - name: /usr/share/npi
+    - source: {{ url }}
+    - source_hash: {{ hash }}
+    - if_missing: /usr/share/npi/npi
+    - archive_format: tar
+    - tar_options: -z --strip-components=1
+
+configure_npi:
+  cmd.run:
+    - name: ./npi set license_key {{ pillar['secrets']['NEW_RELIC_LICENSE_KEY'] }} && ./npi set user {{ pillar['project_name'] }} && ./npi set distro debian
+    - cwd: /usr/share/npi
+{% endif %}


### PR DESCRIPTION
* Import logic from current Margarita to manage the New Relic plugin for Elasticsearch (i.e., the ``npi`` stuff), adjusting for this project's odd "newrelic_license_key" spelling.
* Enable the cluster and node names in the Elasticsearch config (matching that aspect of the Elasticsearch config in current Margarita) so that a meaningful name is seen in the New Relic console, without configuring it in the New Relic plugin.
